### PR TITLE
Feat/ci error mailing

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -32,7 +32,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          DOCKER_REPO="${DOCKER_USER}/${REPO}"
+          # Normalizar para lowercase (Docker exige nomes minúsculos)
+          DOCKER_USER_LC="$(echo "${DOCKER_USER}" | tr '[:upper:]' '[:lower:]')"
+          REPO_LC="$(echo "${REPO}" | tr '[:upper:]' '[:lower:]')"
+          DOCKER_REPO="${DOCKER_USER_LC}/${REPO_LC}"
+
           git fetch --tags --force
 
           TAG_NAME="$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"

--- a/.github/workflows/error-mailing.yml
+++ b/.github/workflows/error-mailing.yml
@@ -2,7 +2,9 @@ name: Alerta de Erro Versionamento
 
 on:
   workflow_run:
-    workflows: ["01 - Análise Semântica Pós-Merge"]
+    workflows:
+      - "01 - Análise Semântica Pós-Merge"
+      - "02 - Buildar e publicar imagem Docker"
     types: [completed]
 
 permissions:
@@ -51,7 +53,7 @@ jobs:
 
       - name: Montar JSON do e-mail (SendGrid)
         run: |
-          SUBJECT="[ALERTA] Falha no workflow de versionamento"
+          SUBJECT="[ALERTA] Falha no workflow: ${{ github.event.workflow_run.name }}"
           BODY_JSON=$(jq -Rs . email_body.txt)
 
           cat > email.json <<'JSON'
@@ -74,7 +76,6 @@ jobs:
           sed -i.bak "s|__TO__|${{ secrets.SENDGRID_TO }}|g" email.json
           sed -i.bak "s|__FROM__|${{ secrets.SENDGRID_FROM }}|g" email.json
           sed -i.bak "s|__SUBJECT__|$SUBJECT|g" email.json
-          # Injeta corpo já serializado em JSON (BODY_JSON já contém aspas e escapes corretos)
           BODY_ESCAPED=$(cat <<< "$BODY_JSON")
           perl -0777 -pe "s|__BODY__|$BODY_ESCAPED|g" -i email.json
           rm -f email.json.bak

--- a/.github/workflows/error-mailing.yml
+++ b/.github/workflows/error-mailing.yml
@@ -1,0 +1,106 @@
+name: Alerta de Erro Versionamento
+
+on:
+  workflow_run:
+    workflows: ["01 - Análise Semântica Pós-Merge"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  enviar-alerta:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Baixar logs do workflow com falha
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          echo "Run ID: ${{ github.event.workflow_run.id }}"
+          curl -L \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/logs \
+            -o logs.zip
+          unzip -q logs.zip -d logs || true
+
+          # Extrai até 200 linhas relevantes (error/fatal/failed/exception)
+          find logs -type f -name "*.txt" -print0 | xargs -0 grep -i -E "error|fatal|failed|exception" | head -n 200 > errors.txt || true
+          if [ ! -s errors.txt ]; then
+            echo "Nenhuma linha contendo erros; adicionando últimas 200 linhas do primeiro log."
+            FIRST_LOG=$(find logs -type f -name "*.txt" | head -n1)
+            if [ -n "$FIRST_LOG" ]; then
+              tail -n 200 "$FIRST_LOG" > errors.txt
+            else
+              echo "Sem logs disponíveis." > errors.txt
+            fi
+          fi
+
+          {
+            echo "Workflow: ${{ github.event.workflow_run.name }}"
+            echo "Run ID: ${{ github.event.workflow_run.id }}"
+            echo "Conclusão: ${{ github.event.workflow_run.conclusion }}"
+            echo "URL Execução: ${{ github.event.workflow_run.html_url }}"
+            echo ""
+            echo "Recorte de erros/log:"
+            echo "--------------------------------------"
+            cat errors.txt
+          } > email_body.txt
+
+      - name: Montar JSON do e-mail (SendGrid)
+        run: |
+          SUBJECT="[ALERTA] Falha no workflow de versionamento"
+          BODY_JSON=$(jq -Rs . email_body.txt)
+
+          cat > email.json <<'JSON'
+          {
+            "personalizations": [
+              {
+                "to": [
+                  { "email": "__TO__" }
+                ]
+              }
+            ],
+            "from": { "email": "__FROM__" },
+            "subject": "__SUBJECT__",
+            "content": [
+              { "type": "text/plain", "value": __BODY__ }
+            ]
+          }
+          JSON
+
+          sed -i.bak "s|__TO__|${{ secrets.SENDGRID_TO }}|g" email.json
+          sed -i.bak "s|__FROM__|${{ secrets.SENDGRID_FROM }}|g" email.json
+          sed -i.bak "s|__SUBJECT__|$SUBJECT|g" email.json
+          # Injeta corpo já serializado em JSON (BODY_JSON já contém aspas e escapes corretos)
+          BODY_ESCAPED=$(cat <<< "$BODY_JSON")
+          perl -0777 -pe "s|__BODY__|$BODY_ESCAPED|g" -i email.json
+          rm -f email.json.bak
+
+          echo "Preview do payload:"
+          head -n 30 email.json
+
+      - name: Enviar e-mail via SendGrid
+        env:
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+        run: |
+          set -e
+          HTTP_CODE=$(curl -sS -o sendgrid_resp.txt -w "%{http_code}" \
+            -X POST "https://api.sendgrid.com/v3/mail/send" \
+            -H "Authorization: Bearer $SENDGRID_API_KEY" \
+            -H "Content-Type: application/json" \
+            --data-binary @email.json)
+
+          echo "HTTP: $HTTP_CODE"
+          echo "Resposta:"
+          cat sendgrid_resp.txt || true
+
+          if [ "$HTTP_CODE" != "202" ]; then
+            echo "Falha ao enviar e-mail via SendGrid (HTTP $HTTP_CODE)" >&2
+            exit 1
+          fi
+
+      - name: Log final
+        run: echo "Alerta de erro enviado por e-mail (SendGrid)."


### PR DESCRIPTION
This pull request introduces an automated error alert workflow for CI failures and improves Docker image publishing reliability by enforcing lowercase repository names. The most significant changes are the addition of a new GitHub Actions workflow for error notifications and a fix to ensure Docker repository names meet Docker's requirements.

**Error notification workflow:**

* Added `.github/workflows/error-mailing.yml` to automatically send an email alert via SendGrid when either the semantic analysis or Docker build workflow fails. The workflow downloads logs, extracts relevant error lines, formats them, and sends a notification to the configured recipients.

**Docker publishing reliability:**

* Updated `.github/workflows/docker-ci.yml` to normalize both `DOCKER_USER` and `REPO` to lowercase before constructing the Docker repository name, preventing errors due to uppercase characters in Docker image names.