### PR TITLE
hotfix: normalize verification code comparison and add debug log

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -85,7 +85,14 @@ export const AuthController = {
         .json({ error: "Dados de verificação não encontrados ou expirados." });
     }
 
-    if (tempData.code !== code) {
+    // Normalize and compare as strings so frontends that send numbers still match
+    const expectedCode = String(tempData.code || "").trim();
+    const receivedCode = String(code || "").trim();
+
+    if (expectedCode !== receivedCode) {
+      console.warn(
+        `Falha na verificação: código esperado=${expectedCode} recebido=${receivedCode} (email=${email})`
+      );
       return res.status(400).json({ error: "Código de verificação inválido." });
     }
 


### PR DESCRIPTION
Esta solicitação de pull introduz uma melhoria na lógica de comparação do código de verificação no `AuthController`. A alteração garante que os códigos sejam comparados consistentemente como strings, o que ajuda a evitar incompatibilidades quando o frontend envia o código como um número em vez de uma string. Além disso, um log de aviso foi adicionado para auxiliar na depuração quando a verificação falha.

Melhorias na comparação do código de verificação:

* Normalizou os códigos de verificação esperados e recebidos para strings antes da comparação, evitando incompatibilidades relacionadas ao tipo durante a autenticação.

* Adicionou um log de aviso com detalhes dos códigos esperados e recebidos, bem como o e-mail, para auxiliar na solução de problemas de verificações com falha.