### PR TITLE
 Release stag to main 2026-05-07 (1)

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -70,5 +70,3 @@ jobs:
           file: ./Dockerfile.prod
           push: true
           tags: ${{ steps.prepare-tags.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
hotfix(ci): remove caching configuration from Docker build step

This pull request makes a small change to the Docker CI workflow by removing the build cache configuration. The build process will no longer use or store build cache with GitHub Actions.

- Removed `cache-from` and `cache-to` settings from the Docker build step in `.github/workflows/docker-ci.yml`.