### PR TITLE
Fix/remove aws credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,9 +60,6 @@ MONGODB_URI=mongodb://localhost:27017/logs_db
 # AWS
 # ============================================================
 AWS_REGION_CW=us-east-1
-AWS_ACCESS_KEY_ID_CW=sua_access_key_id
-AWS_SECRET_ACCESS_KEY_CW=sua_secret_access_key
-AWS_SESSION_TOKEN_CW=seu_session_token_se_necessario
 CLOUDWATCH_LOG_GROUP=/seu-projeto/backend
 CLOUDWATCH_LOG_STREAM=backend-local
 ENABLE_CLOUDWATCH=false

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -59,6 +59,7 @@ jobs:
             # ── Subir novo container ──────────────────────────────────────
             sudo docker run -d \
               --name delbicos-backend \
+              --restart on-failure:3 \
               -v /home/$EC2_USER/.env:/app/.env:ro \
               -p 3000:3000 \
               "${IMAGE}"

--- a/src/config/s3Config.ts
+++ b/src/config/s3Config.ts
@@ -5,9 +5,4 @@ dotenv.config();
 
 export const s3Client = new S3Client({
   region: process.env.AWS_REGION,
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",
-    sessionToken: process.env.AWS_SESSION_TOKEN,
-  },
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -66,11 +66,6 @@ if (shouldEnableCloudWatch && process.env.AWS_ACCESS_KEY_ID_CW) {
     logGroupName: "/fatec/projeto-pi/backend",
     logStreamName: `${os.hostname()}-${new Date().toISOString().split("T")[0]}`,
     awsOptions: {
-      credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID_CW!,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY_CW!,
-        sessionToken: process.env.AWS_SESSION_TOKEN_CW,
-      },
       region: process.env.AWS_REGION_CW || "us-east-1",
     },
     messageFormatter: ({ level, message, ...meta }) =>
@@ -92,11 +87,6 @@ if (shouldEnableCloudWatch && process.env.AWS_ACCESS_KEY_ID_CW) {
     logGroupName: "/fatec/projeto-pi/backend",
     logStreamName: `${os.hostname()}-${new Date().toISOString().split("T")[0]}-info`,
     awsOptions: {
-      credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID_CW!,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY_CW!,
-        sessionToken: process.env.AWS_SESSION_TOKEN_CW,
-      },
       region: process.env.AWS_REGION_CW || "us-east-1",
     },
     messageFormatter: ({ level, message, ...meta }) =>


### PR DESCRIPTION
This pull request removes the explicit AWS credentials for both S3 and CloudWatch from the codebase and configuration files, likely to improve security and rely on alternative authentication mechanisms (such as instance roles or environment-based credentials). Additionally, it updates the deployment workflow to improve container reliability.

**AWS Credentials Removal:**

* Removed explicit AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`) from the S3 client configuration in `src/config/s3Config.ts`.
* Removed explicit AWS CloudWatch credentials (`AWS_ACCESS_KEY_ID_CW`, `AWS_SECRET_ACCESS_KEY_CW`, `AWS_SESSION_TOKEN_CW`) from the logger configuration in `src/utils/logger.ts`. [[1]](diffhunk://#diff-0b242f99cdb5b36e8a0aa886862c30c2f480aca7512bcfc3e2fa4889055d4544L69-L73) [[2]](diffhunk://#diff-0b242f99cdb5b36e8a0aa886862c30c2f480aca7512bcfc3e2fa4889055d4544L95-L99)
* Deleted AWS CloudWatch credential variables from `.env.example` to prevent storing sensitive information in example configuration.

**Deployment Improvements:**

* Added `--restart on-failure:3` to the Docker run command in `.github/workflows/deploy-ec2.yml` to automatically restart the container up to three times if it fails, increasing deployment resilience.