### PR TITLE
Fix/swagger prod ec2

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,6 +1,8 @@
 import { Options } from "swagger-jsdoc";
 
-const isProduction = process.env.NODE_ENV === "production";
+const isProduction =
+  process.env.ENVIRONMENT === "production" ||
+  process.env.NODE_ENV === "production";
 
 const swaggerOptions: Options = {
   definition: {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,8 +1,16 @@
 import { Options } from "swagger-jsdoc";
+import path from "path";
 
 const isProduction =
   process.env.ENVIRONMENT === "production" ||
   process.env.NODE_ENV === "production";
+
+// In production, __dirname is /app/dist/src/config — resolve up to dist/src/
+// In development, __dirname is /…/src/config — resolve up to src/
+const routesGlob = path.resolve(__dirname, "../routes/*.js");
+const modelsGlob = path.resolve(__dirname, "../models/*.js");
+const routesGlobTs = path.resolve(__dirname, "../routes/*.ts");
+const modelsGlobTs = path.resolve(__dirname, "../models/*.ts");
 
 const swaggerOptions: Options = {
   definition: {
@@ -20,9 +28,7 @@ const swaggerOptions: Options = {
       },
     ],
   },
-  apis: isProduction
-    ? ["./dist/routes/*.js", "./dist/models/*.js"]
-    : ["./src/routes/*.ts", "./src/models/*.ts"],
+  apis: isProduction ? [routesGlob, modelsGlob] : [routesGlobTs, modelsGlobTs],
 };
 
 export default swaggerOptions;

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,5 +1,7 @@
 import { Options } from "swagger-jsdoc";
 
+const isProduction = process.env.NODE_ENV === "production";
+
 const swaggerOptions: Options = {
   definition: {
     openapi: "3.0.0",
@@ -12,11 +14,13 @@ const swaggerOptions: Options = {
       { url: "http://localhost:3000/api", description: "Servidor local" },
       {
         url: "https://delbicosbackend.onrender.com/api",
-        description: "Servidor de produção",
+        description: "Servidor de produção (Render)",
       },
     ],
   },
-  apis: ["./src/routes/*.ts", "./src/models/*.ts"],
+  apis: isProduction
+    ? ["./dist/routes/*.js", "./dist/models/*.js"]
+    : ["./src/routes/*.ts", "./src/models/*.ts"],
 };
 
 export default swaggerOptions;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "removeComments": false
   },
   "include": ["server.ts", "src/**/*.ts"],
   "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/__tests__/**"]


### PR DESCRIPTION
This pull request updates the Swagger configuration and TypeScript build settings to better support both development and production environments. The main changes include environment-based path selection for Swagger API docs and a minor adjustment to the TypeScript compiler options.

**Swagger configuration improvements:**

* [`src/config/swagger.ts`](diffhunk://#diff-b8dbdf1e4fab16eb2787cf3f7a768ba3ff9f63b26c02760955ba0a2f7e5094d2R3-R4): Swagger now uses `.js` files from the `dist` directory for API documentation in production, and `.ts` files from `src` during development. This ensures the correct files are referenced depending on the environment. [[1]](diffhunk://#diff-b8dbdf1e4fab16eb2787cf3f7a768ba3ff9f63b26c02760955ba0a2f7e5094d2R3-R4) [[2]](diffhunk://#diff-b8dbdf1e4fab16eb2787cf3f7a768ba3ff9f63b26c02760955ba0a2f7e5094d2L15-R23)
* [`src/config/swagger.ts`](diffhunk://#diff-b8dbdf1e4fab16eb2787cf3f7a768ba3ff9f63b26c02760955ba0a2f7e5094d2L15-R23): Updated the description for the production server to clarify it's the Render deployment.

**TypeScript build configuration:**

* [`tsconfig.build.json`](diffhunk://#diff-3ae20d611c1c7263a9c1bce0449291ebfea1c5d578b3fcdbb596353ad885db25L6-R7): Added `"removeComments": false` to ensure that comments are preserved in the compiled JavaScript output.