### PR TITLE
Fix/category images

### DIFF
--- a/migrations/20260521200642-add-image-url-to-category.js
+++ b/migrations/20260521200642-add-image-url-to-category.js
@@ -1,0 +1,12 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('category', 'image_url', {
+      type: Sequelize.STRING(255),
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('category', 'image_url');
+  }
+};

--- a/seeders/20260521201254-add-image-url-to-categories.js
+++ b/seeders/20260521201254-add-image-url-to-categories.js
@@ -1,0 +1,64 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Mapeamento dos links de imagem para cada título de categoria correspondente
+    const categoryImages = [
+      {
+        title: "Saúde & Bem-Estar",
+        image_url: "https://delbicos-assets.s3.us-east-1.amazonaws.com/saude-e-bem-estar.png",
+      },
+      {
+        title: "Beleza & Estética",
+        image_url: "https://delbicos-assets.s3.us-east-1.amazonaws.com/beleza-e-estetica.png",
+      },
+      {
+        title: "Reformas & Reparos",
+        image_url: "https://delbicos-assets.s3.us-east-1.amazonaws.com/reparos-e-reformas.png",
+      },
+      {
+        title: "Serviços Gerais",
+        image_url: "https://delbicos-assets.s3.us-east-1.amazonaws.com/servicos-gerais.png",
+      },
+      {
+        title: "Serviços Domésticos",
+        image_url: "https://delbicos-assets.s3.us-east-1.amazonaws.com/servicos-domesticos.png",
+      },
+      {
+        title: "Pet",
+        image_url: "https://images.unsplash.com/photo-1583337130417-3346a1be7dee?q=80&w=800&auto=format&fit=crop",
+      },
+    ];
+
+    // Atualiza linha por linha baseado no título exato
+    for (const category of categoryImages) {
+      await queryInterface.bulkUpdate(
+        "category",
+        { 
+          image_url: category.image_url,
+          updated_at: new Date()
+        },
+        { title: category.title }
+      );
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Caso precise dar undo nessa seed específica, ela limpa os campos de imagem
+    await queryInterface.bulkUpdate(
+      "category",
+      { image_url: null },
+      {
+        title: [
+          "Saúde & Bem-Estar",
+          "Beleza & Estética",
+          "Reformas & Reparos",
+          "Serviços Gerais",
+          "Serviços Domésticos",
+          "Pet",
+        ],
+      }
+    );
+  },
+};

--- a/src/models/Category.ts
+++ b/src/models/Category.ts
@@ -35,7 +35,7 @@ export class CategoryModel extends Model<
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
 }
-
+  
 CategoryModel.init(
   {
     id: {

--- a/src/models/Category.ts
+++ b/src/models/Category.ts
@@ -15,6 +15,7 @@ export interface ICategory {
   id?: number;
   title: string;
   description?: string;
+  imageUrl?: string;
   active?: boolean;
 }
 
@@ -27,6 +28,7 @@ export class CategoryModel extends Model<
   public id!: number;
   public title!: string;
   public description?: string;
+  public imageUrl?: string;
   public active?: boolean;
 
   // Timestamps
@@ -49,6 +51,11 @@ CategoryModel.init(
     description: {
       type: DataTypes.TEXT,
       allowNull: true,
+    },
+    imageUrl: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      field: "image_url",
     },
     active: {
       type: DataTypes.BOOLEAN,


### PR DESCRIPTION
Ajustada a tabela 'Category' para receber o atributo 'image_url' para renderização no frontend. Criado migrate para inserção do campo via Sequelize e uma seed foi criada referenciando as imagens de cada categoria, que está hospedada em bucket s3 do delbicos-asset

<img width="1516" height="628" alt="image" src="https://github.com/user-attachments/assets/c40a948c-004a-4935-aa8a-cdcd7c7895b6" />
