### PR TITLE
Filter services by category_id through subcategory association instea…

### DIFF
--- a/src/controllers/service.controller.ts
+++ b/src/controllers/service.controller.ts
@@ -145,9 +145,6 @@ export const listAllServices = async (req: Request, res: Response) => {
 
     const where: any = { active: true };
 
-    if (category_id && Number.isInteger(Number(category_id)))
-      where.category_id = Number(category_id);
-
     if (subcategory_id && Number.isInteger(Number(subcategory_id)))
       where.subcategory_id = Number(subcategory_id);
 
@@ -166,15 +163,20 @@ export const listAllServices = async (req: Request, res: Response) => {
       avInclude.required = true;
     }
 
+    const subInclude: any = {
+      model: SubCategoryModel,
+      as: "Subcategory",
+      attributes: ["id", "title", "category_id"],
+    };
+    if (category_id && Number.isInteger(Number(category_id))) {
+      subInclude.where = { category_id: Number(category_id) };
+    }
+
     const { count, rows } = await ServiceModel.findAndCountAll({
       where,
       include: [
         avInclude,
-        {
-          model: SubCategoryModel,
-          as: "Subcategory",
-          attributes: ["id", "title", "category_id"],
-        },
+        subInclude,
         {
           model: ProfessionalModel,
           as: "Professional",


### PR DESCRIPTION
# 🔧 Correção no Filtro de Serviços por Categoria (Backend)
Este Pull Request corrige a lógica de consulta e filtragem de serviços com base no identificador de categoria (`category_id`) no backend, prevenindo erros de SQL/Sequelize na listagem geral.
---
### 🛠️ Alterações Realizadas
#### 🔍 Ajuste na Consulta de Serviços (`src/controllers/service.controller.ts`)
* **Filtragem por Categoria Associada**: Corrigido o método `listAllServices`. Anteriormente, o backend tentava injetar o filtro `category_id` diretamente na cláusula `where` principal do modelo `ServiceModel` (o qual não possui relação direta de coluna/atributo para isso na tabela de serviços).
* **Filtro via Subcategoria (JOIN)**: Alterado para injetar o filtro condicionalmente dentro da relação de subcategoria associada (`SubCategoryModel`), utilizando a cláusula `where` no `include`:
  ```typescript
  const subInclude: any = {
    model: SubCategoryModel,
    as: "Subcategory",
    attributes: ["id", "title", "category_id"],
  };
  if (category_id && Number.isInteger(Number(category_id))) {
    subInclude.where = { category_id: Number(category_id) };
  }