### PR TITLE
Release stag to main 2026-05-31 (2) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:all": "jest --no-coverage"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
     "@aws-sdk/client-s3": "^3.1037.0",
     "@aws-sdk/lib-storage": "^3.1037.0",
     "@aws-sdk/s3-request-presigner": "^3.1038.0",


### PR DESCRIPTION
hotfix: add missing dependency @aws-sdk/client-cloudwatch-logs to package.json