### PR TITLE
Feat/img bb proxy for s3

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -37,6 +37,7 @@ import serviceRoutes from "./src/routes/service.routes";
 import availabilityRoutes from "./src/routes/availability.routes";
 import availabilityLockRoutes from "./src/routes/availabilityLock.routes";
 import uploadRoutes from "./src/routes/upload.routes";
+import proxyUploadRoutes from "./src/routes/proxyUpload.routes";
 
 dotenv.config();
 
@@ -107,6 +108,7 @@ app.use("/api/services", serviceRoutes);
 app.use("/api/availabilities", availabilityRoutes);
 app.use("/api/availability-locks", availabilityLockRoutes);
 app.use("/api/uploads", uploadRoutes);
+app.use("/api/proxy-upload", proxyUploadRoutes);
 
 const isServerless = process.env.IS_SERVERLESS == "true";
 

--- a/src/controllers/avatar.controller.ts
+++ b/src/controllers/avatar.controller.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from "express";
-import { S3Service } from "../services/s3Service";
 import { UserModel } from "../models/User";
-
-const s3Service = new S3Service();
+import { getStorageAdapter } from "../services/storage/StorageFactory";
 
 export const AvatarController = {
   listFiles: async (req: Request, res: Response) => {
     try {
-      const files = await s3Service.listFiles();
+      const files = await getStorageAdapter().listFiles();
       res.json(files);
     } catch (error: any) {
       res.status(500).json({ error: error.message });
@@ -17,7 +15,7 @@ export const AvatarController = {
   getFileUrl: async (req: Request, res: Response) => {
     try {
       const { key } = req.params;
-      const url = await s3Service.getFileUrl(key);
+      const url = await getStorageAdapter().getFileUrl(key);
       res.json({ url });
     } catch (error: any) {
       res.status(500).json({ error: error.message });
@@ -27,8 +25,8 @@ export const AvatarController = {
   getPresignedUrl: async (req: Request, res: Response) => {
     try {
       const { fileName, fileType } = req.body;
-      const uploadUrl = await s3Service.generateUploadUrl(fileName, fileType);
-      const fileUrl = `https://${process.env.S3_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${fileName}`;
+      const { uploadUrl, fileUrl } =
+        await getStorageAdapter().generateUploadUrl(fileName, fileType);
       res.json({ uploadUrl, fileUrl });
     } catch (error: any) {
       res.status(500).json({ error: error.message });
@@ -38,8 +36,11 @@ export const AvatarController = {
   getUserAvatar: async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const user = await UserModel.findByPk(id, { attributes: ["id", "avatar_uri"] });
-      if (!user) return res.status(404).json({ error: "Usuário não encontrado" });
+      const user = await UserModel.findByPk(id, {
+        attributes: ["id", "avatar_uri"],
+      });
+      if (!user)
+        return res.status(404).json({ error: "Usuário não encontrado" });
       res.json({ avatar_uri: user.avatar_uri });
     } catch (error: any) {
       res.status(500).json({ error: "Erro ao buscar avatar" });
@@ -47,40 +48,41 @@ export const AvatarController = {
   },
 
   updateAvatarDatabase: async (req: Request, res: Response) => {
-  try {
-    const userId = (req as any).userId;
-    const userObject = (req as any).user;
-    const { avatar_uri } = req.body;
+    try {
+      const userId = (req as any).userId;
+      const userObject = (req as any).user;
+      const { avatar_uri } = req.body;
 
-    console.log("--- DEBUG UPDATE PATH ---");
-    console.log("req.userId:", userId);
-    console.log("req.user:", userObject);
-    console.log("Body:", req.body);
+      console.log("--- DEBUG UPDATE PATH ---");
+      console.log("req.userId:", userId);
+      console.log("req.user:", userObject);
+      console.log("Body:", req.body);
 
-    const finalId = userId || userObject?.id || userObject?._id;
+      const finalId = userId || userObject?.id || userObject?._id;
 
-    if (!finalId) {
-      return res.status(401).json({ 
-        error: "401 - Não foi possível extrair o ID do usuário do token." 
+      if (!finalId) {
+        return res.status(401).json({
+          error: "401 - Não foi possível extrair o ID do usuário do token.",
+        });
+      }
+
+      const user = await UserModel.findByPk(finalId);
+
+      if (!user) {
+        return res
+          .status(404)
+          .json({ error: "Usuário não encontrado no banco." });
+      }
+
+      await user.update({ avatar_uri });
+
+      return res.json({
+        mensagem: "Perfil atualizado no banco!",
+        avatar_uri,
       });
+    } catch (error: any) {
+      console.error("ERRO NO UPDATE:", error);
+      return res.status(500).json({ error: error.message });
     }
-
-    const user = await UserModel.findByPk(finalId);
-    
-    if (!user) {
-      return res.status(404).json({ error: "Usuário não encontrado no banco." });
-    }
-
-    await user.update({ avatar_uri });
-    
-    return res.json({ 
-      mensagem: "Perfil atualizado no banco!", 
-      avatar_uri 
-    });
-
-  } catch (error: any) {
-    console.error("ERRO NO UPDATE:", error);
-    return res.status(500).json({ error: error.message });
-  }
-}
+  },
 };

--- a/src/controllers/proxyUpload.controller.ts
+++ b/src/controllers/proxyUpload.controller.ts
@@ -1,0 +1,73 @@
+import { Request, Response } from "express";
+import { pendingUploads } from "../services/storage/ImgBBStorageAdapter";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * PUT /api/proxy-upload/:token
+ *
+ * Recebe o binário enviado pelo frontend, encaminha ao ImgBB e retorna a URL pública.
+ * Esse endpoint só é ativado quando STORAGE_PROVIDER=imgbb.
+ */
+export const proxyUpload = async (req: Request, res: Response) => {
+  const { token } = req.params;
+
+  const pending = pendingUploads.get(token);
+  if (!pending) {
+    return res
+      .status(404)
+      .json({ error: "Token de upload inválido ou expirado" });
+  }
+
+  if (Date.now() > pending.expiresAt) {
+    pendingUploads.delete(token);
+    return res.status(410).json({ error: "Token de upload expirado" });
+  }
+
+  pendingUploads.delete(token);
+
+  // Coleta o corpo da requisição como Buffer
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve, reject) => {
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", resolve);
+    req.on("error", reject);
+  });
+
+  const buffer = Buffer.concat(chunks);
+  if (buffer.length === 0) {
+    return res.status(400).json({ error: "Corpo da requisição vazio" });
+  }
+
+  const apiKey = process.env.IMGBB_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: "IMGBB_API_KEY não configurada" });
+  }
+
+  const base64 = buffer.toString("base64");
+  const imageName = uuidv4();
+
+  const body = new URLSearchParams({
+    key: apiKey,
+    image: base64,
+    name: imageName,
+  });
+
+  const imgbbResponse = await fetch("https://api.imgbb.com/1/upload", {
+    method: "POST",
+    body,
+  });
+
+  const data = (await imgbbResponse.json()) as {
+    success: boolean;
+    data?: { url: string };
+    error?: { message: string };
+  };
+
+  if (!data.success || !data.data?.url) {
+    return res.status(502).json({
+      error: data.error?.message || "Falha ao enviar imagem para o ImgBB",
+    });
+  }
+
+  return res.json({ fileUrl: data.data.url });
+};

--- a/src/controllers/upload.controller.ts
+++ b/src/controllers/upload.controller.ts
@@ -1,8 +1,6 @@
 import { Response } from "express";
 import { AuthenticatedRequest } from "../interfaces/authentication.interface";
-import { S3Service } from "../services/s3Service";
-
-const s3Service = new S3Service();
+import { getStorageAdapter } from "../services/storage/StorageFactory";
 
 /**
  * POST /api/uploads
@@ -39,8 +37,11 @@ export const getUploadUrl = async (
     const safeName = fileName.replace(/[^a-zA-Z0-9._-]/g, "_");
     const key = `uploads/${Date.now()}_${safeName}`;
 
-    const uploadUrl = await s3Service.generateUploadUrl(key, fileType);
-    const fileUrl = `https://${process.env.S3_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
+    const { uploadUrl, fileUrl: adapterFileUrl } =
+      await getStorageAdapter().generateUploadUrl(key, fileType);
+    const fileUrl =
+      adapterFileUrl ??
+      `https://${process.env.S3_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
 
     // Retorna ambos os nomes de campo para compatibilidade com frontend e backend
     return res.json({

--- a/src/routes/proxyUpload.routes.ts
+++ b/src/routes/proxyUpload.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { proxyUpload } from "../controllers/proxyUpload.controller";
+
+const router = Router();
+
+/**
+ * Recebe o binário do frontend e faz o upload para o ImgBB.
+ * Usado somente quando STORAGE_PROVIDER=imgbb.
+ * O token é gerado pelo ImgBBStorageAdapter no momento do POST /upload-url.
+ */
+router.put("/:token", proxyUpload);
+
+export default router;

--- a/src/services/storage/ImgBBStorageAdapter.ts
+++ b/src/services/storage/ImgBBStorageAdapter.ts
@@ -1,0 +1,45 @@
+import crypto from "crypto";
+import { StorageAdapter, UploadUrlResult } from "./StorageAdapter";
+
+interface PendingUpload {
+  fileType: string;
+  expiresAt: number;
+}
+
+/**
+ * Armazena os tokens de upload pendentes em memória.
+ * Chave: token UUID  |  Valor: metadados do upload esperado
+ */
+export const pendingUploads = new Map<string, PendingUpload>();
+
+/** TTL dos tokens em ms (5 minutos) */
+const TOKEN_TTL_MS = 5 * 60 * 1000;
+
+export class ImgBBStorageAdapter implements StorageAdapter {
+  async generateUploadUrl(
+    fileName: string,
+    fileType: string,
+  ): Promise<UploadUrlResult> {
+    const token = crypto.randomUUID();
+    pendingUploads.set(token, {
+      fileType,
+      expiresAt: Date.now() + TOKEN_TTL_MS,
+    });
+
+    // Caminho relativo — o frontend detecta que começa com "/" e usa o backendHttpClient
+    const uploadUrl = `/api/proxy-upload/${token}`;
+
+    // fileUrl não é conhecido antes do upload no ImgBB
+    return { uploadUrl, fileUrl: null };
+  }
+
+  async getFileUrl(key: string): Promise<string> {
+    // No ImgBB a URL já é pública e permanente — key é a própria URL
+    return key;
+  }
+
+  async listFiles() {
+    // ImgBB não tem API de listagem acessível — retorna vazio
+    return [];
+  }
+}

--- a/src/services/storage/S3StorageAdapter.ts
+++ b/src/services/storage/S3StorageAdapter.ts
@@ -1,0 +1,23 @@
+import { StorageAdapter, UploadUrlResult } from "./StorageAdapter";
+import { S3Service } from "../s3Service";
+
+export class S3StorageAdapter implements StorageAdapter {
+  private s3 = new S3Service();
+
+  async generateUploadUrl(
+    fileName: string,
+    fileType: string,
+  ): Promise<UploadUrlResult> {
+    const uploadUrl = await this.s3.generateUploadUrl(fileName, fileType);
+    const fileUrl = `https://${process.env.S3_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${fileName}`;
+    return { uploadUrl, fileUrl };
+  }
+
+  async getFileUrl(key: string): Promise<string> {
+    return this.s3.getFileUrl(key);
+  }
+
+  async listFiles() {
+    return this.s3.listFiles();
+  }
+}

--- a/src/services/storage/StorageAdapter.ts
+++ b/src/services/storage/StorageAdapter.ts
@@ -1,0 +1,39 @@
+export interface UploadUrlResult {
+  /** URL para onde o frontend deve fazer PUT com o binário */
+  uploadUrl: string;
+  /**
+   * URL pública final do arquivo.
+   * - S3: já conhecida antes do upload (baseada no bucket/key)
+   * - ImgBB: null antes do upload; o proxy retornará o valor real na resposta do PUT
+   */
+  fileUrl: string | null;
+}
+
+export interface StorageAdapter {
+  /**
+   * Gera os endereços de upload para um arquivo.
+   * @param fileName  Nome/key do arquivo (ex: "uploads/123_avatar.jpg")
+   * @param fileType  MIME type (ex: "image/jpeg")
+   */
+  generateUploadUrl(
+    fileName: string,
+    fileType: string,
+  ): Promise<UploadUrlResult>;
+
+  /**
+   * Retorna a URL de visualização de um arquivo já armazenado.
+   * @param key Identificador do arquivo no provider
+   */
+  getFileUrl(key: string): Promise<string>;
+
+  /**
+   * Lista todos os arquivos armazenados (usado para debug).
+   */
+  listFiles(): Promise<
+    {
+      name: string | undefined;
+      size: number | undefined;
+      lastModified: Date | undefined;
+    }[]
+  >;
+}

--- a/src/services/storage/StorageFactory.ts
+++ b/src/services/storage/StorageFactory.ts
@@ -1,0 +1,19 @@
+import { StorageAdapter } from "./StorageAdapter";
+import { S3StorageAdapter } from "./S3StorageAdapter";
+import { ImgBBStorageAdapter } from "./ImgBBStorageAdapter";
+
+let instance: StorageAdapter | null = null;
+
+export function getStorageAdapter(): StorageAdapter {
+  if (instance) return instance;
+
+  const provider = process.env.STORAGE_PROVIDER || "s3";
+
+  if (provider === "imgbb") {
+    instance = new ImgBBStorageAdapter();
+  } else {
+    instance = new S3StorageAdapter();
+  }
+
+  return instance;
+}


### PR DESCRIPTION
This pull request introduces a flexible storage adapter system that allows the application to support both S3 and ImgBB as file storage providers. It abstracts file upload, retrieval, and listing behind a common interface, and adds a proxy upload route to handle ImgBB uploads securely. The main changes are grouped below:

**Storage Abstraction and Adapter Implementation:**

* Introduced a `StorageAdapter` interface and `UploadUrlResult` type in `src/services/storage/StorageAdapter.ts`, defining a common contract for file upload, retrieval, and listing operations.
* Added `S3StorageAdapter` and `ImgBBStorageAdapter` classes implementing the `StorageAdapter` interface, encapsulating provider-specific logic. The ImgBB adapter manages pending upload tokens and does not support file listing. [[1]](diffhunk://#diff-de2cc4140c92e0b103f227277fe5b357f989bcd998a266c89e69e84c13e0ba9dR1-R23) [[2]](diffhunk://#diff-492906805cc5ff1b517176284c61798563d0acfca1c8acd88d4f58aa264f9b62R1-R45)

**Dynamic Storage Provider Selection:**

* Implemented a `getStorageAdapter` factory in `src/services/storage/StorageFactory.ts` to select and instantiate the appropriate adapter based on the `STORAGE_PROVIDER` environment variable.

**Controller Refactoring for Adapter Usage:**

* Refactored `avatar.controller.ts` and `upload.controller.ts` to use the new `getStorageAdapter()` instead of directly using `S3Service`, ensuring all file operations are provider-agnostic. [[1]](diffhunk://#diff-1f5dec60267f3b8dcbed4630e5fffe532ee6db2c33986d3fa1f894a0d0fa18abL2-R8) [[2]](diffhunk://#diff-1f5dec60267f3b8dcbed4630e5fffe532ee6db2c33986d3fa1f894a0d0fa18abL20-R18) [[3]](diffhunk://#diff-1f5dec60267f3b8dcbed4630e5fffe532ee6db2c33986d3fa1f894a0d0fa18abL30-R29) [[4]](diffhunk://#diff-233334de6d6d32a786745bb9e7a3284536d81ea7d20e2a936528828e7a1339dcL3-R3) [[5]](diffhunk://#diff-233334de6d6d32a786745bb9e7a3284536d81ea7d20e2a936528828e7a1339dcL42-R44)

**ImgBB Proxy Upload Endpoint:**

* Added a new `PUT /api/proxy-upload/:token` endpoint (with controller, route, and service logic) to receive file binaries from the frontend and upload them to ImgBB, using a token-based system for security and single-use uploads. [[1]](diffhunk://#diff-da2dd61d0e91d77fa7914d292877787a997f55c68d8064eedc79c4fe7f1f931cR1-R73) [[2]](diffhunk://#diff-a95387aef937ce679089e2ab7df50f09b409ed5542a6ccaaa6a3b88016492e64R1-R13) [[3]](diffhunk://#diff-1ba718c1eb8aa39cd20c2562d92523068c734d75f54655e97d652b992d9b4259R40) [[4]](diffhunk://#diff-1ba718c1eb8aa39cd20c2562d92523068c734d75f54655e97d652b992d9b4259R111) [[5]](diffhunk://#diff-492906805cc5ff1b517176284c61798563d0acfca1c8acd88d4f58aa264f9b62R1-R45)

These changes make the file upload system extensible and secure, allowing seamless switching between S3 and ImgBB as storage backends.