### PR TITLE
feat(lambda): render HTML emails with HTML alternative and plain-text…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,7 @@ AWS_REGION_CW=us-east-1
 CLOUDWATCH_LOG_GROUP=/seu-projeto/backend
 CLOUDWATCH_LOG_STREAM=backend-local
 ENABLE_CLOUDWATCH=false
+
+# Lambda fallback (Function URL) - opcional
+# Se preenchido, o backend tentará invocar essa URL quando o envio por SendGrid falhar
+LAMBDA_FUNCTION_URL=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - EXPIRES_IN=${EXPIRES_IN:-24h}
       - SENDGRID_API_KEY=${SENDGRID_API_KEY:-sk_API_KEY}
       - SENDER_EMAIL_VERIFICADO=${SENDER_EMAIL_VERIFICADO:-deliverydebicos@gmail.com}
+      - LAMBDA_FUNCTION_URL=${LAMBDA_FUNCTION_URL:-}
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-sk_API_KEY}
       - MONGODB_URI=mongodb://mongo:27017/logs_db
     volumes:

--- a/lambda_email/README.md
+++ b/lambda_email/README.md
@@ -1,0 +1,37 @@
+Resumo
+
+- Função Lambda mínima em Python para enviar e-mail via SMTP (substitui SendGrid localmente).
+
+Pré-requisitos
+
+- `aws` CLI configurado
+- `sam` CLI (opcional, para deploy simplificado)
+- Conta AWS com permissões para criar Lambda
+
+Variáveis de ambiente importantes
+
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `FROM_EMAIL`
+
+Como empacotar e fazer deploy com SAM
+
+```bash
+cd lambda_email
+sam build
+sam deploy --guided
+```
+
+Testando localmente com `aws lambda invoke` (após deploy)
+
+```bash
+aws lambda invoke --function-name <NomeDaFuncao> --payload '{"to":"seu@email.com","subject":"Teste","body":"Olá"}' response.json
+cat response.json
+```
+
+Testar rapidamente local (sem AWS):
+
+- Você pode executar `handler.lambda_handler` localmente definindo variáveis de ambiente e chamando a função via um pequeno script Python.
+
+Observações importantes
+
+- Emails enviados diretamente podem cair em SPAM. Para produção, configure SPF/DKIM e use um serviço de envio confiável.
+- Se quer que os envs sejam armazenados no código (temporário), configure no `template.yaml` ou no painel Lambda.

--- a/lambda_email/lambda_function.py
+++ b/lambda_email/lambda_function.py
@@ -1,0 +1,91 @@
+import os
+import json
+import re
+import smtplib
+from email.message import EmailMessage
+
+SMTP_HOST = os.environ.get('SMTP_HOST')
+SMTP_PORT = int(os.environ.get('SMTP_PORT', 587))
+SMTP_USER = os.environ.get('SMTP_USER')
+SMTP_PASS = os.environ.get('SMTP_PASS')
+FROM_EMAIL = os.environ.get('FROM_EMAIL')
+DEFAULT_SUBJECT = os.environ.get('DEFAULT_SUBJECT', 'Teste de e-mail')
+
+
+def send_email(to_address: str, subject: str, body: str) -> None:
+    msg = EmailMessage()
+    msg['From'] = FROM_EMAIL or SMTP_USER or 'no-reply@example.com'
+    msg['To'] = to_address
+    msg['Subject'] = subject
+    # Provide a plain-text fallback and add HTML alternative so clients render correctly
+    plain = re.sub('<[^<]+?>', '', body or '')
+    msg.set_content(plain or (body or ''))
+    # Add HTML alternative (email clients will prefer this when available)
+    msg.add_alternative(body or '', subtype='html')
+
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=15) as s:
+        s.ehlo()
+        if SMTP_PORT in (587, 25):
+            s.starttls()
+        if SMTP_USER and SMTP_PASS:
+            s.login(SMTP_USER, SMTP_PASS)
+        s.send_message(msg)
+
+
+def _extract_payload(event: dict) -> dict:
+    # Handle direct test events (keys at top-level)
+    if isinstance(event.get('to'), str):
+        return {
+            'to': event.get('to'),
+            'subject': event.get('subject'),
+            'body': event.get('body'),
+        }
+
+    # Handle API Gateway / Function URL (v2) where body is a JSON string
+    body = event.get('body')
+    if body:
+        if isinstance(body, str):
+            try:
+                parsed = json.loads(body)
+                return {
+                    'to': parsed.get('to'),
+                    'subject': parsed.get('subject'),
+                    'body': parsed.get('body'),
+                }
+            except Exception:
+                # body may be raw text
+                return {'to': None, 'subject': None, 'body': body}
+        elif isinstance(body, dict):
+            return {
+                'to': body.get('to'),
+                'subject': body.get('subject'),
+                'body': body.get('body'),
+            }
+
+    # Fallback: try top-level keys again
+    return {
+        'to': event.get('recipient') or event.get('to'),
+        'subject': event.get('subject'),
+        'body': event.get('body'),
+    }
+
+
+def lambda_handler(event, context):
+    print('Received event:', event)
+    try:
+        payload = _extract_payload(event or {})
+        to = payload.get('to')
+        subject = payload.get('subject') or DEFAULT_SUBJECT
+        body = payload.get('body') or 'Mensagem enviada pela Lambda'
+
+        if not to:
+            return {'statusCode': 400, 'body': 'Missing "to" address'}
+
+        if not SMTP_HOST:
+            return {'statusCode': 500, 'body': 'SMTP_HOST não configurado'}
+
+        send_email(to, subject, body)
+        return {'statusCode': 200, 'body': 'Email enviado'}
+    except Exception as e:
+        print('Error sending email:', e)
+        return {'statusCode': 500, 'body': f'Erro ao enviar email: {e}'}

--- a/lambda_email/template.yaml
+++ b/lambda_email/template.yaml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: Lambda simples para envio de e-mail via SMTP
+Resources:
+  SendEmailFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Runtime: python3.11
+      Timeout: 30
+      MemorySize: 128
+      # Se você NÃO pode criar uma role nova, descomente a linha abaixo e substitua pelo ARN
+      # da role existente que possui a policy `AWSLambdaBasicExecutionRole`.
+      # Role: arn:aws:iam::123456789012:role/YourExistingLambdaRole
+      Environment:
+        Variables:
+          SMTP_HOST: "smtp.example.com"
+          SMTP_PORT: "587"
+          SMTP_USER: ""
+          SMTP_PASS: ""
+          FROM_EMAIL: "no-reply@example.com"
+      Policies:
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Action: "logs:CreateLogGroup"
+              Resource: "arn:aws:logs:*:*:*"
+            - Effect: "Allow"
+              Action:
+                - "logs:CreateLogStream"
+                - "logs:PutLogEvents"
+              Resource: "arn:aws:logs:*:*:*"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/client-s3": "^3.1037.0",
     "@aws-sdk/lib-storage": "^3.1037.0",
     "@aws-sdk/s3-request-presigner": "^3.1038.0",
+    "@aws-sdk/client-lambda": "^3.1038.0",
     "@logtail/node": "^0.5.6",
     "@logtail/winston": "^0.5.6",
     "@sendgrid/mail": "^8.1.5",

--- a/server.ts
+++ b/server.ts
@@ -110,6 +110,28 @@ app.use("/api/availability-locks", availabilityLockRoutes);
 app.use("/api/uploads", uploadRoutes);
 app.use("/api/proxy-upload", proxyUploadRoutes);
 
+// Test endpoint to invoke email fallback (Lambda) directly
+app.post("/test-email-fallback", async (req, res) => {
+  const { to, subject, body } = req.body || {};
+  if (!to || !subject || !body) {
+    return res
+      .status(400)
+      .json({ error: 'Fields "to", "subject", "body" are required' });
+  }
+  try {
+    // dynamic import to avoid startup dependency issues
+    const { sendViaLambda } = await import("./src/utils/emailFallback");
+    const result = await sendViaLambda({ to, subject, html: body });
+    if (result) return res.status(200).json({ ok: true });
+    return res
+      .status(502)
+      .json({ ok: false, error: "Lambda invocation failed" });
+  } catch (err) {
+    logger.error("Error in /test-email-fallback:", err as any);
+    return res.status(500).json({ ok: false, error: String(err) });
+  }
+});
+
 const isServerless = process.env.IS_SERVERLESS == "true";
 
 if (!isServerless) {

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -1,4 +1,5 @@
 import sgMail from "../config/sendgrid";
+import { sendViaLambda } from "../utils/emailFallback";
 
 interface EmailParams {
   to: string;
@@ -34,6 +35,16 @@ export const EmailService = {
       if (typeof error === "object" && error !== null && "response" in error) {
         const err = error as { response?: { body?: any } };
         console.error(err.response?.body);
+      }
+      // Tentar fallback via Lambda
+      try {
+        const fallbackResult = await sendViaLambda({ to, subject, html });
+        if (fallbackResult) {
+          console.info("E-mail enviado via Lambda fallback");
+          return true;
+        }
+      } catch (err) {
+        console.error("Erro no fallback via Lambda:", err);
       }
       return false;
     }

--- a/src/utils/emailFallback.ts
+++ b/src/utils/emailFallback.ts
@@ -1,0 +1,69 @@
+interface EmailPayload {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+export async function sendViaLambda(payload: EmailPayload): Promise<boolean> {
+  const functionUrl = process.env.LAMBDA_FUNCTION_URL;
+  const functionName = process.env.LAMBDA_FUNCTION_NAME;
+
+  // Try HTTP Function URL first (simpler, no AWS creds needed)
+  if (functionUrl) {
+    try {
+      const resp = await fetch(functionUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          to: payload.to,
+          subject: payload.subject,
+          body: payload.html,
+        }),
+      });
+      return resp.ok;
+    } catch (err) {
+      console.error("Erro ao chamar Lambda Function URL:", err);
+      // fallthrough to try SDK if available
+    }
+  }
+
+  // If no Function URL, try invoking Lambda via AWS SDK (requires AWS creds + permission)
+  if (functionName) {
+    try {
+      // dynamic import so project can still run if dependency not installed
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { LambdaClient, InvokeCommand } =
+        await import("@aws-sdk/client-lambda");
+      const client = new LambdaClient({
+        region: process.env.AWS_REGION || "us-east-1",
+      });
+      const command = new InvokeCommand({
+        FunctionName: functionName,
+        Payload: Buffer.from(
+          JSON.stringify({
+            to: payload.to,
+            subject: payload.subject,
+            body: payload.html,
+          }),
+        ),
+      });
+      const result = await client.send(command);
+      if (
+        result.StatusCode &&
+        result.StatusCode >= 200 &&
+        result.StatusCode < 300
+      )
+        return true;
+      console.error("Lambda invoke returned non-2xx:", result);
+      return false;
+    } catch (err) {
+      console.error("Erro ao invocar Lambda via SDK:", err);
+      return false;
+    }
+  }
+
+  console.error(
+    "Nenhuma forma de invocar Lambda configurada (LAMBDA_FUNCTION_URL ou LAMBDA_FUNCTION_NAME)",
+  );
+  return false;
+}


### PR DESCRIPTION
Esta solicitação de pull introduz um mecanismo de fallback de e-mail baseado em Lambda no backend, permitindo que e-mails sejam enviados por meio de uma função AWS Lambda personalizada (usando SMTP) caso a entrega principal do SendGrid falhe. Inclui uma função Lambda Python mínima, recursos de implantação e integração em todo o serviço de backend. Também adiciona opções de configuração e um endpoint de teste para invocação local e remota.

**Mecanismo de fallback para e-mail via Lambda**
- Adicionada uma função Lambda Python mínima (`lambda_email/lambda_function.py`) para enviar e-mails via SMTP, incluindo extração robusta de payload e tratamento de erros. Um arquivo `template.yaml` para implantação no AWS SAM e um arquivo `README.md` com instruções de configuração/teste também são fornecidos.
[[1]](diffhunk://#diff-bb4a27290fe767414bc1a351849fb343793587f4e509816bb442dde8f5b5e78eR1-R91)
[[2]](diffhunk://#diff-86a2f4b406a241ec3abcf46 17edea7e12452e5917848cef6769bd70f30878d08R1-R32)
[[3]](diffhunk://#diff-2514ba64723a7c4cc11d432b2aec943305d59b76d31c27f1b712b598c03fc7aaR1-R37)

- Novas variáveis ​​de ambiente (`LAMBDA_FUNCTION_URL`) introduzidas em `.env.example` e propagadas para `docker-compose.yml` para configurar o endpoint de fallback do Lambda.
[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR66-R69)
[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R44)

**Integração com o Backend**
- Implementada a utilidade `sendViaLambda` em `src/utils/emailFallback.ts` para invocar a função Lambda via HTTP (URL da função) ou AWS SDK, com importações dinâmicas para minimizar o impacto em ambientes sem dependências da AWS.

- Atualizado o `EmailService` (`src/services/email.service.ts`) para tentar o envio via fallback do Lambda caso o SendGrid falhe, com registro de logs tanto para casos de sucesso quanto de falha.
[[1]](diffhunk://#diff-155b9ec33dcb0739bd0fc59e4ed36e4069ce7c4a01bbe9d71502fddd44e04769R2)
[[2]](diffhunk://#diff-155b9ec33dcb0739bd0fc59e4ed36e4069ce7c4a01bbe9d71502fddd44e04769R39-R48)
- Adicionamos um endpoint de teste (`/test-email-fallback`) em `server.ts` para permitir o teste direto do caminho de e-mail alternativo do Lambda.

**Dependências**
- Adicionada a dependência `@aws-sdk/client-lambda` ao `package.json` para suporte à invocação do Lambda.… fallback


<img width="1845" height="786" alt="image" src="https://github.com/user-attachments/assets/852b46aa-e775-41a2-830f-a1ab79442802" />
<img width="1782" height="445" alt="image" src="https://github.com/user-attachments/assets/766e9bd6-4bb4-46ba-9f74-fa12c406bad8" />
<img width="1509" height="701" alt="image" src="https://github.com/user-attachments/assets/0fe17837-6616-4ef1-bbaf-3786b6055086" />

