### PR TITLE
Fix/neon connection

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,4 +1,9 @@
 const path = require("path");
+require("dotenv").config();
+
+if (!process.env.NODE_ENV && process.env.ENVIRONMENT) {
+  process.env.NODE_ENV = process.env.ENVIRONMENT;
+}
 
 module.exports = {
   config: path.resolve("./config", "config.js"),

--- a/config/config.js
+++ b/config/config.js
@@ -2,7 +2,7 @@ require("dotenv").config();
 
 /**
  * Determina o dialect do banco de dados
- * Prioridade: SEQUELIZE_DIALECT > RDS_DIALECT > "mysql"
+ * Prioridade: SEQUELIZE_DIALECT > RDS_DIALECT > "postgres"
  */
 const getDialect = () => {
   if (process.env.SEQUELIZE_DIALECT) {
@@ -20,12 +20,14 @@ const getDialect = () => {
 // No seu src/config/config.js
 const getSSLOptions = (dialect, environment) => {
   if (dialect === "postgres") {
-    if (environment === "development") {
-      return { ssl: false };
+    if (environment === "development" && !process.env.DATABASE_URL) {
+      return undefined;
     }
     return {
-      require: true,
-      rejectUnauthorized: false,
+      ssl: {
+        require: true,
+        rejectUnauthorized: false,
+      },
     };
   }
   return undefined;
@@ -33,6 +35,10 @@ const getSSLOptions = (dialect, environment) => {
 
 const env = process.env.ENVIRONMENT || process.env.NODE_ENV || "development";
 const dialect = getDialect();
+
+const getDefaultPort = (currentDialect) => {
+  return currentDialect === "postgres" ? 5432 : 3306;
+};
 
 if (process.env.__DEV__) {
   console.log("🔧 Sequelize Configuration:");
@@ -53,29 +59,24 @@ const config = {
     password: process.env.SEQUELIZE_DB_PASS || "password",
     database: process.env.SEQUELIZE_DB_NAME || "my_database",
     host: process.env.SEQUELIZE_HOST || "localhost",
-    port: Number(process.env.SEQUELIZE_PORT) || 3306,
+    port: Number(process.env.SEQUELIZE_PORT) || getDefaultPort(dialect),
     dialect,
     dialectOptions: getSSLOptions(dialect, "development"),
     logging: process.env.DB_LOGGING === "true" ? console.log : false,
   },
   production: {
     // Opção 1: DATABASE_URL (Neon Postgres)
-    use_env_variable: process.env.DATABASE_URL ? "DATABASE_URL" : undefined,
+    ...(process.env.DATABASE_URL ? { use_env_variable: "DATABASE_URL" } : {}),
     // Opção 2: Variáveis individuais (AWS RDS MySQL)
     username: process.env.SEQUELIZE_DB_USER,
     password: process.env.SEQUELIZE_DB_PASS,
     database: process.env.SEQUELIZE_DB_NAME,
     host: process.env.SEQUELIZE_HOST,
-    port: Number(process.env.SEQUELIZE_PORT) || 3306,
+    port: Number(process.env.SEQUELIZE_PORT) || getDefaultPort(dialect),
     dialect,
     dialectOptions: getSSLOptions(dialect, env),
     logging: process.env.DB_LOGGING === "true" ? console.log : false,
   },
 };
 
-// Se use_env_variable é undefined, remover a propriedade
-if (config.production.use_env_variable === undefined) {
-  delete config.production.use_env_variable;
-}
-
-module.exports = config[env];
+module.exports = config;


### PR DESCRIPTION
This pull request updates the Sequelize configuration to better support both Postgres and MySQL, with improved handling of environment variables, SSL options, and default ports. The changes make the configuration more flexible and production-ready, especially for deployments using Postgres (such as Neon or RDS).

**Environment variable and configuration improvements:**

* [`.sequelizerc`](diffhunk://#diff-37a3a29e6a7044c228d03f504be0d64ca4f0fcbb5612dc3285c5988848f69cf7R2-R6): Loads environment variables from `.env` and sets `NODE_ENV` from `ENVIRONMENT` if not already set, ensuring consistent environment detection.

**Database dialect and connection handling:**

* [`config/config.js`](diffhunk://#diff-a7c4d97b958033f33a08e9247c6619d20e47465301a5aea82088fcce7b936c5bL5-R5): Changes the default database dialect priority to prefer Postgres over MySQL, aligning with modern cloud database usage.
* [`config/config.js`](diffhunk://#diff-a7c4d97b958033f33a08e9247c6619d20e47465301a5aea82088fcce7b936c5bR39-R42): Adds a helper to select the default port based on the dialect (`5432` for Postgres, `3306` for MySQL), and updates port assignment in both development and production configs to use this logic. [[1]](diffhunk://#diff-a7c4d97b958033f33a08e9247c6619d20e47465301a5aea82088fcce7b936c5bR39-R42) [[2]](diffhunk://#diff-a7c4d97b958033f33a08e9247c6619d20e47465301a5aea82088fcce7b936c5bL56-R82)

**SSL and dialect options:**

* [`config/config.js`](diffhunk://#diff-a7c4d97b958033f33a08e9247c6619d20e47465301a5aea82088fcce7b936c5bL23-R30): Refines SSL options for Postgres connections—returns `undefined` for development unless `DATABASE_URL` is set, and uses the correct SSL structure for production, improving compatibility with managed Postgres providers.

**Production configuration cleanup:**

* [`config/config.js`](diffhunk://#diff-a7c4d97b958033f33a08e9247c6619d20e47465301a5aea82088fcce7b936c5bL56-R82): Changes how `use_env_variable` is set for production to avoid setting it when `DATABASE_URL` is not present, and removes the code that deleted this property after object creation. Now, the config object is exported directly for all environments.